### PR TITLE
Single domain for sb accounts

### DIFF
--- a/lib/arux_app.rb
+++ b/lib/arux_app.rb
@@ -13,7 +13,7 @@ require "arux_app/api/student"
 require "arux_app/api/cart"
 
 module AruxApp
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
   USER_AGENT = "Arux.app GEM #{VERSION}"
 end
 

--- a/lib/arux_app/api.rb
+++ b/lib/arux_app/api.rb
@@ -15,6 +15,16 @@ module AruxApp
           @@mode = b ? m : :standard
         end
       end
+
+      def server_uri
+        if AruxApp::API.standardmode?
+          "https://account.arux.app"
+        elsif AruxApp::API.testmode?
+          "https://account.arux.blue"
+        elsif AruxApp::API.devmode?
+          "https://account.#{HOSTNAME}"
+        end
+      end
     end
     
     class Error < StandardError

--- a/lib/arux_app/api/account.rb
+++ b/lib/arux_app/api/account.rb
@@ -1,16 +1,6 @@
 module AruxApp
   module API
     class Account
-      def self.server_uri
-        if AruxApp::API.standardmode?
-          "https://acc.arux.app"
-        elsif AruxApp::API.testmode?
-          "https://acc.arux.blue"
-        elsif AruxApp::API.devmode?
-          "https://acc.#{HOSTNAME}"
-        end
-      end
-
       attr_accessor :auth, :access_token, :api_version
 
       def initialize(options = {})

--- a/lib/arux_app/api/account.rb
+++ b/lib/arux_app/api/account.rb
@@ -1,6 +1,10 @@
 module AruxApp
   module API
     class Account
+      def self.server_uri
+        AruxApp::API.server_uri
+      end
+
       attr_accessor :auth, :access_token, :api_version
 
       def initialize(options = {})

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -47,7 +47,7 @@ module AruxApp
       end
 
       def authorization_url
-        %(#{self.class.server_uri}/oauth/authorize?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{self.class.server_uri}/oauth/authorize?response_type=code&client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end
 
       def registration_url

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -47,7 +47,7 @@ module AruxApp
       end
 
       def authorization_url
-        %(#{self.class.server_uri}/oauth/authorize?scopes=public&response_type=code&client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{self.class.server_uri}/oauth/authorize?scope=public&response_type=code&client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end
 
       def registration_url

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -47,11 +47,11 @@ module AruxApp
       end
 
       def authorization_url
-        %(#{self.class.server_uri}/authorize?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{self.class.server_uri}/users/sign_in?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end
 
       def registration_url
-        %(#{self.class.server_uri}/register?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{self.class.server_uri}/users/registrations?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end
 
       def access_token(code)

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -47,7 +47,7 @@ module AruxApp
       end
 
       def authorization_url
-        %(#{self.class.server_uri}/oauth/authorize?response_type=code&client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{self.class.server_uri}/oauth/authorize?scopes=public&response_type=code&client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end
 
       def registration_url

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -47,7 +47,7 @@ module AruxApp
       end
 
       def authorization_url
-        %(#{self.class.server_uri}/users/sign_in?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{self.class.server_uri}/oauth/authorize?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end
 
       def registration_url
@@ -64,7 +64,7 @@ module AruxApp
         }
 
         request = HTTPI::Request.new
-        request.url = "#{self.class.server_uri}/access_token"
+        request.url = "#{self.class.server_uri}/oauth/token"
         request.body = data
         request.headers = {'User-Agent' => USER_AGENT}
 

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -25,16 +25,6 @@ module AruxApp
         end
       end
 
-      def self.server_uri
-        if AruxApp::API.standardmode?
-          "https://sso.arux.app"
-        elsif AruxApp::API.testmode?
-          "https://sso.arux.blue"
-        elsif AruxApp::API.devmode?
-          "https://sso.#{HOSTNAME}"
-        end
-      end
-
       attr_accessor :client_id, :client_secret, :redirect_uri, :js_callback, :district_subdomain, :current_user_uuid, :login_mechanism, :element
 
       def initialize(options = {})

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -25,6 +25,10 @@ module AruxApp
         end
       end
 
+      def self.server_uri
+        AruxApp::API.server_uri
+      end
+
       attr_accessor :client_id, :client_secret, :redirect_uri, :js_callback, :district_subdomain, :current_user_uuid, :login_mechanism, :element
 
       def initialize(options = {})


### PR DESCRIPTION
### What has been done. 
- Adds all the necessary changes for the Doorkeeper OAuth2 flow via https://github.com/Arux-Software/switchboard_accounts/pull/365
- Updates the domain from `sso` and `acc` to `account`. 

### What needs to be done.
- Update the `sso` `acc` references in TCE to match `account`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204787839602812