### PR TITLE
Accounts Next Client Credentials

### DIFF
--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -87,6 +87,27 @@ module AruxApp
         end
       end
 
+      def client_credentials_token
+        data = {
+          scope: "public",
+          grant_type: "client_credentials",
+          client_id: client_id,
+          client_secret: client_secret
+        }
+
+        request = HTTPI::Request.new
+        request.url = "#{self.class.server_uri}/oauth/token"
+        request.body = data
+        request.headers = {'User-Agent' => USER_AGENT}
+
+        response = HTTPI.post(request)
+        if !response.error?
+          AccessToken.new(:token => JSON.parse(response.body)['access_token'], auth: self)
+        else
+          raise(API::Error.new(response.code, response.body))
+        end
+      end
+
       def javascript
         options = {
           district: self.district_subdomain,


### PR DESCRIPTION
**Asana Task** [Update to Client Credentials Flow for M2M API's](https://app.asana.com/0/1201090112237353/1205853331993531/f)

[Accounts Next PR](https://github.com/Arux-Software/switchboard_accounts/pull/400)

### Changes
This builds out a method that will `POST` to the auth token endpoint.
It will take the `client_id` and `client_secret` and exchange them for an access token.