### PR TITLE
Prepare for RubyGems Publish

### DIFF
--- a/arux_app.gemspec
+++ b/arux_app.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name           = "arux.app"
+  spec.name           = "arux_app"
   spec.version        = "1.0.0"
   spec.authors        = ["Arux Software"]
   spec.email          = ["sheuer@aruxsoftware.com"]

--- a/lib/arux_app.rb
+++ b/lib/arux_app.rb
@@ -1,6 +1,6 @@
-require 'rubygems'
-require 'httpi'
-require 'json'
+require "rubygems"
+require "httpi"
+require "json"
 
 require "arux_app/api"
 


### PR DESCRIPTION
### Notice

The current state of this PR has been published to [RubyGems](https://rubygems.org/gems/arux_app). Any modifications to this PR and/or subsequent commits will require a rebuild and repush. This should be merged in to main only once all applications in production have been updated and verified to be pointing to the publish gem. **Do not merge until then**.

### Details


This changes the gemspec and gets it ready for publishing, some things to note.

Once we publish it any changes usually are going to be a bump in version and we'll be using semantic versioning. 

To follow [RubyGems](https://guides.rubygems.org/name-your-gem/) conventions (and to match what the file name is arux_app).

- https://stackoverflow.com/questions/21029195/when-do-you-need-a-require-in-a-rails-gemfile/21029304#21029304

This should allow us to drop the require and simply call gem "arux_app"

From

```
gem "arux.app", git: "https://github.com/Arux-Software/arux_app_gem.git", branch: "main", require: "arux_app" (required because of the difference from convention)
```

To
```
gem "arux_app"
```

~Because we do have the require right now, I would expect all our current apps to be fine even with this merged in but once this is published we can update all our apps to just call `gem "arux_app` and retrieve it from RubyGems~ This requires coordinated changes. Will need to update.


Note:

Once all apps are using this, whenever we make changes and merge to main. It will require updating the spec, bumping the version, and then pushing the updated gem. (You do not need to commit the gem that you build to the repo).