### PR TITLE
Update calls to URI.parse

### DIFF
--- a/lib/arux_app/api.rb
+++ b/lib/arux_app/api.rb
@@ -6,11 +6,11 @@ module AruxApp
         define_method("#{m}mode?") do
           @@mode == m
         end
-        
+
         define_method("#{m}mode") do
           @@mode == m
         end
-        
+
         define_method("#{m}mode=") do |b|
           @@mode = b ? m : :standard
         end
@@ -25,8 +25,18 @@ module AruxApp
           "https://account.#{HOSTNAME}"
         end
       end
+
+      def uri_escape(str)
+        if URI.respond_to?(:escape)
+          URI.escape(str)
+        elsif defined? URI::DEFAULT_PARSER
+          URI::DEFAULT_PARSER.escape(str)
+        else
+          CGI.escape(str)
+        end
+      end
     end
-    
+
     class Error < StandardError
       attr_accessor :http_status_code
       def initialize(code, message)
@@ -35,19 +45,19 @@ module AruxApp
           self.json = JSON.parse(message)
         rescue
         end
-        
+
         super "(#{code}) #{message}"
       end
     end
-    
+
     class InitializerError < StandardError
-      def initialize(method, message)        
+      def initialize(method, message)
         super "#{method} #{message}"
       end
     end
 
     class RequirementError < StandardError
-      def initialize(method, message)        
+      def initialize(method, message)
         super "#{method} #{message}"
       end
     end

--- a/lib/arux_app/api.rb
+++ b/lib/arux_app/api.rb
@@ -27,6 +27,11 @@ module AruxApp
       end
 
       def uri_escape(str)
+        # URI.escape was deprecated and removed in ruby
+        # https://bugs.ruby-lang.org/issues/17309
+        # The alternatives suggested were using URI::DEFAULT_PARSER
+        # and CGI. This will use URI::DEFAULT_PARSER if it is defined and CGI
+        # if not.
         if URI.respond_to?(:escape)
           URI.escape(str)
         elsif defined? URI::DEFAULT_PARSER

--- a/lib/arux_app/api/account.rb
+++ b/lib/arux_app/api/account.rb
@@ -33,7 +33,7 @@ module AruxApp
       end
 
       def get(uuid, params = {})
-        uuid = URI.escape(uuid.to_s)
+        uuid = AruxApp::API.uri_escape(uuid.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{uuid}"
@@ -67,7 +67,7 @@ module AruxApp
       end
 
       def update(uuid, params)
-        uuid = URI.escape(uuid.to_s)
+        uuid = AruxApp::API.uri_escape(uuid.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{uuid}"
@@ -86,8 +86,8 @@ module AruxApp
       end
 
       def merge(uuid1, uuid2)
-        uuid1 = URI.escape(uuid1)
-        uuid2 = URI.escape(uuid2)
+        uuid1 = AruxApp::API.uri_escape(uuid1)
+        uuid2 = AruxApp::API.uri_escape(uuid2)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/merge/#{uuid1}/#{uuid2}"
@@ -103,7 +103,7 @@ module AruxApp
       end
 
       def delete(uuid)
-        uuid = URI.escape(uuid.to_s)
+        uuid = AruxApp::API.uri_escape(uuid.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{uuid}"
@@ -136,7 +136,7 @@ module AruxApp
       end
 
       def list_user_locks(user_uuid)
-        uuid = URI.escape(user_uuid.to_s)
+        uuid = AruxApp::API.uri_escape(user_uuid.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{user_uuid}/locks"
@@ -152,7 +152,7 @@ module AruxApp
       end
 
       def add_user_lock(user_uuid, scope, reason = "")
-        uuid = URI.escape(user_uuid.to_s)
+        uuid = AruxApp::API.uri_escape(user_uuid.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{uuid}/locks"
@@ -176,7 +176,7 @@ module AruxApp
       end
 
       def delete_user_lock(user_uuid, lock_id)
-        uuid = URI.escape(user_uuid.to_s)
+        uuid = AruxApp::API.uri_escape(user_uuid.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{api_route}/users/#{uuid}/locks/#{lock_id}"

--- a/lib/arux_app/api/bank_info.rb
+++ b/lib/arux_app/api/bank_info.rb
@@ -6,14 +6,14 @@ module AruxApp
       end
 
       def get(routing_number)
-        routing_number = URI.escape(routing_number.to_s)
+        routing_number = AruxApp::API.uri_escape(routing_number.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{self.class.server_uri}/#{routing_number}"
         request.headers = {'User-Agent' => USER_AGENT}
 
         response = HTTPI.get(request)
-        
+
         if !response.error?
           JSON.parse(response.body)
         else

--- a/lib/arux_app/api/cart.rb
+++ b/lib/arux_app/api/cart.rb
@@ -23,7 +23,7 @@ module AruxApp
 
       def get(uuid = nil)
         if uuid
-          path = %(/api/#{URI.escape(uuid)})
+          path = %(/api/#{AruxApp::API.uri_escape(uuid)})
         else
           path = %(/api/#{self.generate_cart_path})
         end
@@ -110,7 +110,7 @@ module AruxApp
       end
 
       def update_item(item_identifier, params)
-        path = %(/api/#{self.generate_cart_path}/items/#{URI.escape(item_identifier)})
+        path = %(/api/#{self.generate_cart_path}/items/#{AruxApp::API.uri_escape(item_identifier)})
 
         request = HTTPI::Request.new
         request.url = "#{self.class.server_uri}#{path}"
@@ -130,7 +130,7 @@ module AruxApp
       end
 
       def delete_item(item_identifier)
-        path = %(/api/#{self.generate_cart_path}/items/#{URI.escape(item_identifier)})
+        path = %(/api/#{self.generate_cart_path}/items/#{AruxApp::API.uri_escape(item_identifier)})
 
         request = HTTPI::Request.new
         request.url = "#{self.class.server_uri}#{path}"
@@ -179,7 +179,7 @@ module AruxApp
       protected
 
       def generate_cart_path
-        %(#{URI.escape(self.auth.district_subdomain)}/#{URI.escape(self.access_token.token)})
+        %(#{AruxApp::API.uri_escape(self.auth.district_subdomain)}/#{AruxApp::API.uri_escape(self.access_token.token)})
       end
 
       def generate_headers

--- a/lib/arux_app/api/config.rb
+++ b/lib/arux_app/api/config.rb
@@ -21,7 +21,7 @@ module AruxApp
       end
 
       def get(subdomain_or_sn)
-        subdomain_or_sn = URI.escape(subdomain_or_sn.to_s)
+        subdomain_or_sn = AruxApp::API.uri_escape(subdomain_or_sn.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{self.class.server_uri}/v1/customers/#{subdomain_or_sn}"
@@ -37,8 +37,8 @@ module AruxApp
       end
 
       def get_by(key, value)
-        key = URI.escape(key.to_s)
-        value = URI.escape(value.to_s)
+        key = AruxApp::API.uri_escape(key.to_s)
+        value = AruxApp::API.uri_escape(value.to_s)
 
         request = HTTPI::Request.new
         request.url = "#{self.class.server_uri}/v1/customers/by/#{key}/#{value}"

--- a/lib/arux_app/api/student.rb
+++ b/lib/arux_app/api/student.rb
@@ -7,7 +7,7 @@ module AruxApp
         # firstname & lastname & birthdate
         # state_student_id
         request = HTTPI::Request.new
-        request.url = "#{self.class.server_uri}/api/v1/students/lookup/district_student_id/#{URI.escape(self.auth.district_subdomain)}"
+        request.url = "#{self.class.server_uri}/api/v1/students/lookup/district_student_id/#{AruxApp::API.uri_escape(self.auth.district_subdomain)}"
         request.query = params
         request.headers = self.generate_headers
 
@@ -25,7 +25,7 @@ module AruxApp
         # firstname & lastname & birthdate
         # district_student_id
         request = HTTPI::Request.new
-        request.url = "#{self.class.server_uri}/api/v1/students/lookup/state_student_id/#{URI.escape(self.auth.district_subdomain)}"
+        request.url = "#{self.class.server_uri}/api/v1/students/lookup/state_student_id/#{AruxApp::API.uri_escape(self.auth.district_subdomain)}"
         request.query = params
         request.headers = self.generate_headers
 


### PR DESCRIPTION
URI.escape was deprecated and removed in later ruby versions.

This updates our calls to `URI.escape` to go through `AruxApp::API.uri_escape` which will call `URI.escape` if it is defined other wise fallback to try `URI::DEFAULT_PARSER` or `CGI`.