### PR TITLE
Add basic authentication

### DIFF
--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -76,16 +76,13 @@ module AruxApp
         end
 
         response = HTTPI.post(request)
+        raise(API::Error.new(response.code, response.body)) if response.error?
 
-        if !response.error?
-          AccessToken.new(
-            token: JSON.parse(response.body)['access_token'],
-            scope: JSON.parse(response.body)['scope'],
-            auth: self
-          )
-        else
-          raise(API::Error.new(response.code, response.body))
-        end
+        AccessToken.new(
+          token: JSON.parse(response.body)['access_token'],
+          scope: JSON.parse(response.body)['scope'],
+          auth: self
+        )
       end
 
 

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -67,11 +67,14 @@ module AruxApp
           client_id: client_id,
           client_secret: client_secret
         }
-        request = HTTPI::Request.new
-        request.url = "#{self.class.server_uri}/oauth/token"
-        request.body = params
-        request.headers = { 'User-Agent' => USER_AGENT }
-        request.auth.basic(username, password)
+
+        request = HTTPI::Request.new.tap do |req|
+          req.url = "#{self.class.server_uri}/oauth/token"
+          req.body = params
+          req.headers = { 'User-Agent' => USER_AGENT }
+          req.auth.basic(username, password)
+        end
+
         response = HTTPI.post(request)
 
         if !response.error?

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -85,7 +85,6 @@ module AruxApp
         )
       end
 
-
       def registration_url
         %(#{self.class.server_uri}/users/registrations?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -65,8 +65,7 @@ module AruxApp
           scope: scope,
           grant_type: "password",
           client_id: client_id,
-          redirect_uri: redirect_uri,
-          district: district_subdomain
+          client_secret: client_secret
         }
         request = HTTPI::Request.new
         request.url = "#{self.class.server_uri}/oauth/token"

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -60,6 +60,33 @@ module AruxApp
         base_uri.to_s
       end
 
+      def basic_authentication(username, password, scope = "public")
+        params = {
+          scope: scope,
+          grant_type: "password",
+          client_id: client_id,
+          redirect_uri: redirect_uri,
+          district: district_subdomain
+        }
+        request = HTTPI::Request.new
+        request.url = "#{self.class.server_uri}/oauth/token"
+        request.body = params
+        request.headers = { 'User-Agent' => USER_AGENT }
+        request.auth.basic(username, password)
+        response = HTTPI.post(request)
+
+        if !response.error?
+          AccessToken.new(
+            token: JSON.parse(response.body)['access_token'],
+            scope: JSON.parse(response.body)['scope'],
+            auth: self
+          )
+        else
+          raise(API::Error.new(response.code, response.body))
+        end
+      end
+
+
       def registration_url
         %(#{self.class.server_uri}/users/registrations?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
       end


### PR DESCRIPTION
**Update Client Credentials flow for Courses API** [Asana Task](https://app.asana.com/0/1206395725449160/1206174762676768/f)

### Changes

This adds logic for the [Password Grant](https://www.oauth.com/oauth2-servers/access-tokens/password-grant/) flow. Which allows us to send Basic Auth (username/password) credentials to Accounts Next. 

### Test
Reference [Courses API PR](https://github.com/Arux-Software/onsite_courses_api/pull/37)