### PR TITLE
Update httpi dependency to 3.0

### DIFF
--- a/arux.app.gemspec
+++ b/arux.app.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name           = "arux_app"
-  spec.version        = "3.0.0"
+  spec.version        = "3.0.1"
   spec.authors        = ["Arux Software"]
   spec.email          = ["sheuer@aruxsoftware.com"]
   spec.summary        = "Ruby gem for interacting with the Arux.app Switchboard APIs."

--- a/arux.app.gemspec
+++ b/arux.app.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files     = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths  = ["lib"]
   
-  spec.add_runtime_dependency "httpi", "~> 2.4"
+  spec.add_runtime_dependency "httpi", "~> 3.0"
   spec.add_runtime_dependency "json", ">= 0"
 
   spec.add_development_dependency "bundler", ">= 1.14"

--- a/lib/arux_app.rb
+++ b/lib/arux_app.rb
@@ -18,6 +18,6 @@ require "arux_app/api/account"
 require "arux_app/api/cart"
 
 module AruxApp
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
   USER_AGENT = "Arux.app GEM #{VERSION}"
 end


### PR DESCRIPTION
## Changes
Newer versions of Dalli (Switchboard Accounts) were having an issue
when trying to connect through the socksify dependency.
[httpi 3.0 changelog](https://my.diffend.io/gems/httpi/2.5.0/3.0.0#d2h-670634)


```
Dalli::Server#connect memcache:11211 /usr/local/bundle/gems/socksify-1.7.1/lib/socksify.rb:178:in `initialize': no implicit conversion of Hash into String (TypeError)  initialize_tcp host, port, local_host, local_port
```

httpi 3.0 no longer uses the socksify dependency.


## Test
1. Point the gem to this branch 
 - Accounts
 - TCE 
 - Cart
```ruby
gem 'arux_app', git: "https://github.com/Arux-Software/arux_app_gem", branch: "geenen/update-httpi-version"
```

3. Bring containers and volumes down
4. Bundle
5. Build and bring containers back up
6. Log in as a public user 
7. Add a course to the cart
8. Checkout
