### PR TITLE
Use the new registration route

### DIFF
--- a/arux.app.gemspec
+++ b/arux.app.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name           = "arux_app"
-  spec.version        = "3.0.1"
+  spec.version        = "3.0.2"
   spec.authors        = ["Arux Software"]
   spec.email          = ["sheuer@aruxsoftware.com"]
   spec.summary        = "Ruby gem for interacting with the Arux.app Switchboard APIs."
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables    = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files     = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths  = ["lib"]
-  
+
   spec.add_runtime_dependency "httpi", "~> 3.0"
   spec.add_runtime_dependency "json", ">= 0"
 

--- a/lib/arux_app.rb
+++ b/lib/arux_app.rb
@@ -18,6 +18,6 @@ require "arux_app/api/account"
 require "arux_app/api/cart"
 
 module AruxApp
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
   USER_AGENT = "Arux.app GEM #{VERSION}"
 end

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -98,7 +98,7 @@ module AruxApp
       end
 
       def registration_url
-        %(#{public_uri}/users/registrations?client_id=#{self.client_id}&redirect_uri=#{self.redirect_uri}&district=#{self.district_subdomain})
+        %(#{public_uri}/users/sign_up&district=#{self.district_subdomain})
       end
 
       def access_token(code)

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -98,7 +98,7 @@ module AruxApp
       end
 
       def registration_url
-        %(#{public_uri}/users/sign_up&district=#{self.district_subdomain})
+        %(#{public_uri}/users/sign_up?district=#{self.district_subdomain})
       end
 
       def access_token(code)


### PR DESCRIPTION
This pull request includes a minor change to the `registration_url` method in the `lib/arux_app/api/auth.rb` file. The change updates the URL used for user registration.

* [`lib/arux_app/api/auth.rb`](diffhunk://#diff-7e4fb19fc6c6477e36c0df9fbffc264a3e35d87d3bb598390b942294c5ec7c12L101-R101): Modified the `registration_url` method to update the URL for user registration. The new URL is `%(#{public_uri}/users/sign_up?district=#{self.district_subdomain})` instead of the previous URL which included `client_id` and `redirect_uri` parameters.