### PR TITLE
3.0.3: Update Gem to remove private Gem

### DIFF
--- a/arux.app.gemspec
+++ b/arux.app.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name           = "arux_app"
-  spec.version        = "3.0.2"
+  spec.version        = "3.0.3"
   spec.authors        = ["Arux Software"]
   spec.email          = ["sheuer@aruxsoftware.com"]
   spec.summary        = "Ruby gem for interacting with the Arux.app Switchboard APIs."

--- a/lib/arux_app.rb
+++ b/lib/arux_app.rb
@@ -18,6 +18,6 @@ require "arux_app/api/account"
 require "arux_app/api/cart"
 
 module AruxApp
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
   USER_AGENT = "Arux.app GEM #{VERSION}"
 end

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -26,7 +26,7 @@ module AruxApp
         end
       end
 
-      attr_accessor :client_id, :client_secret, :redirect_uri, :js_callback, :district_subdomain, :current_user_uuid, :login_mechanism, :element
+      attr_accessor :client_id, :client_secret, :redirect_uri, :js_callback, :district_subdomain, :current_user_uuid, :login_mechanism, :element, :api_key
 
       def initialize(options = {})
         self.client_id = options[:client_id]
@@ -41,6 +41,8 @@ module AruxApp
         raise API::InitializerError.new(:client_id, "can't be blank") if self.client_id.to_s.empty?
         raise API::InitializerError.new(:client_secret, "can't be blank") if self.client_secret.to_s.empty?
         raise API::InitializerError.new(:redirect_uri, "can't be blank") if self.redirect_uri.to_s.empty?
+
+        self.api_key = options[:api_key]
       end
 
       def self.public_uri

--- a/lib/arux_app/api/auth.rb
+++ b/lib/arux_app/api/auth.rb
@@ -37,12 +37,11 @@ module AruxApp
         self.element = options[:element]
         self.district_subdomain = options[:district_subdomain]
         self.current_user_uuid = options[:current_user_uuid]
+        self.api_key = options[:api_key]
 
         raise API::InitializerError.new(:client_id, "can't be blank") if self.client_id.to_s.empty?
         raise API::InitializerError.new(:client_secret, "can't be blank") if self.client_secret.to_s.empty?
         raise API::InitializerError.new(:redirect_uri, "can't be blank") if self.redirect_uri.to_s.empty?
-
-        self.api_key = options[:api_key]
       end
 
       def self.public_uri

--- a/lib/arux_app/api/config.rb
+++ b/lib/arux_app/api/config.rb
@@ -6,8 +6,8 @@ module AruxApp
       def initialize(options = {})
         self.auth = options[:auth]
 
-        raise API::InitializerError.new(:auth, "can't be blank") if auth.nil?
-        raise API::InitializerError.new(:auth, "must be of class type AruxApp::API::Auth") if !auth.is_a?(AruxApp::API::Auth)
+        raise API::InitializerError.new(:auth, "can't be blank") if self.auth.nil?
+        raise API::InitializerError.new(:auth, "must be of class type AruxApp::API::Auth") if !self.auth.is_a?(AruxApp::API::Auth)
       end
 
       def self.public_uri
@@ -31,7 +31,7 @@ module AruxApp
 
         request = HTTPI::Request.new
         request.url = "#{api_uri}/v1/customers/#{subdomain_or_sn}"
-        request.headers = generate_headers
+        request.headers = self.generate_headers
 
         response = HTTPI.get(request)
 
@@ -48,7 +48,7 @@ module AruxApp
 
         request = HTTPI::Request.new
         request.url = "#{api_uri}/v1/customers/by/#{key}/#{value}"
-        request.headers = generate_headers
+        request.headers = self.generate_headers
 
         response = HTTPI.get(request)
 
@@ -75,12 +75,7 @@ module AruxApp
       protected
 
       def generate_headers
-        {
-          "User-Agent": USER_AGENT,
-          "Client-Secret": auth.client_secret,
-          "Client-Id": auth.client_id,
-          key: auth.api_key
-        }
+        {'User-Agent' => USER_AGENT, 'Client-Secret' => self.auth.client_secret, 'Client-Id' => self.auth.client_id, key: auth.api_key}
       end
     end
   end

--- a/lib/arux_app/api/config.rb
+++ b/lib/arux_app/api/config.rb
@@ -75,7 +75,12 @@ module AruxApp
       protected
 
       def generate_headers
-        {'User-Agent' => USER_AGENT, 'Client-Secret' => self.auth.client_secret, 'Client-Id' => self.auth.client_id, key: auth.api_key}
+        {
+          'User-Agent' => USER_AGENT,
+          'Client-Secret' => self.auth.client_secret,
+          'Client-Id' => self.auth.client_id,
+          'Key' => self.auth.api_key
+        }
       end
     end
   end

--- a/lib/arux_app/api/config.rb
+++ b/lib/arux_app/api/config.rb
@@ -6,8 +6,8 @@ module AruxApp
       def initialize(options = {})
         self.auth = options[:auth]
 
-        raise API::InitializerError.new(:auth, "can't be blank") if self.auth.nil?
-        raise API::InitializerError.new(:auth, "must be of class type AruxApp::API::Auth") if !self.auth.is_a?(AruxApp::API::Auth)
+        raise API::InitializerError.new(:auth, "can't be blank") if auth.nil?
+        raise API::InitializerError.new(:auth, "must be of class type AruxApp::API::Auth") if !auth.is_a?(AruxApp::API::Auth)
       end
 
       def self.public_uri
@@ -31,7 +31,7 @@ module AruxApp
 
         request = HTTPI::Request.new
         request.url = "#{api_uri}/v1/customers/#{subdomain_or_sn}"
-        request.headers = self.generate_headers
+        request.headers = generate_headers
 
         response = HTTPI.get(request)
 
@@ -48,7 +48,7 @@ module AruxApp
 
         request = HTTPI::Request.new
         request.url = "#{api_uri}/v1/customers/by/#{key}/#{value}"
-        request.headers = self.generate_headers
+        request.headers = generate_headers
 
         response = HTTPI.get(request)
 
@@ -59,12 +59,29 @@ module AruxApp
         end
       end
 
+      def list(params = {})
+        request = HTTPI::Request.new
+        request.url = "#{api_uri}/v1/p/customers"
+        request.query = URI.encode_www_form(params)
+        request.headers = generate_headers
+        response = HTTPI.get(request)
+        if !response.error?
+          JSON.parse(response.body)
+        else
+          raise(API::Error.new(response.code, response.body))
+        end
+      end
+
       protected
 
       def generate_headers
-        {'User-Agent' => USER_AGENT, 'Client-Secret' => self.auth.client_secret, 'Client-Id' => self.auth.client_id}
+        {
+          "User-Agent": USER_AGENT,
+          "Client-Secret": auth.client_secret,
+          "Client-Id": auth.client_id,
+          key: auth.api_key
+        }
       end
-
     end
   end
 end


### PR DESCRIPTION
The functionality of the Arux.app gem is currently split between the [public gem](https://github.com/Arux-Software/arux_app_gem/tree/c3b81ca9a4355ae98d5dfe81f4d759ded944db34) and [private gem](https://github.com/Arux-Software/arux_app_private_gem/tree/main). Updating this gem by integrating behavior from the private side.
