### PR TITLE
Adding SupportPortal API

### DIFF
--- a/arux.app.gemspec
+++ b/arux.app.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name           = "arux_app"
-  spec.version        = "3.0.3"
+  spec.version        = "3.0.4"
   spec.authors        = ["Arux Software"]
   spec.email          = ["sheuer@aruxsoftware.com"]
   spec.summary        = "Ruby gem for interacting with the Arux.app Switchboard APIs."

--- a/lib/arux_app/api/support_portal.rb
+++ b/lib/arux_app/api/support_portal.rb
@@ -1,0 +1,28 @@
+module AruxApp
+  module API
+    class SupportPortal
+      DOMAINS = {
+        production: "arux.blue",
+        staging: "arux.blue",
+        development: HOSTNAME,
+        test: "arux.test" # do we really need this?
+      }
+
+      def self.public_uri
+        AruxApp::API.uri(subdomain: "support-portal")
+      end
+
+      def public_uri
+        self.class.public_uri
+      end
+
+      def self.api_uri
+        AruxApp::API.uri(subdomain: "support-portal.api")
+      end
+
+      def api_uri
+        self.class.api_uri
+      end
+    end
+  end
+end

--- a/lib/arux_app/api/support_portal.rb
+++ b/lib/arux_app/api/support_portal.rb
@@ -5,7 +5,7 @@ module AruxApp
         production: "arux.blue",
         staging: "arux.blue",
         development: HOSTNAME,
-        test: "arux.test" # do we really need this?
+        test: "arux.test"
       }
 
       def self.public_uri


### PR DESCRIPTION
Adds an API to handle the logic of generating SupportPortal uri's. 

This requires different logic, as "arux.blue" is the production/staging environment for support portal, instead of production having the "arux.app" domain.